### PR TITLE
add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# editors/IDEs
+.vscode/
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.sql
+
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+cmd/mxbench/mxbench
+bin/*
+
+*.conf
+
+mxbench_e2e
+mxbench_race


### PR DESCRIPTION
It is convenient to add a `.gitignore` to inform git that some files are not to be included when it is not forced.
Those files include but are not limited to:
1. Directories and files generated by IDE/editor;
2. SQL files or config files for testing;
3. Files generated by testing;
4. Binary files.