### PR TITLE
fix get the version of matrixdb

### DIFF
--- a/internal/util/dbversion.go
+++ b/internal/util/dbversion.go
@@ -35,11 +35,11 @@ func NewMXDBVersion(version string) (DBVersion, error) {
 	var dbversion DBVersion
 	var err error
 	dbversion.VersionString = version
-	if !strings.Contains(dbversion.VersionString, "YMatrix") {
+	if !strings.Contains(dbversion.VersionString, "MatrixDB") {
 		return dbversion, err
 	}
 
-	versionStart := strings.Index(dbversion.VersionString, "(YMatrix ") + len("(YMatrix ")
+	versionStart := strings.Index(dbversion.VersionString, "(MatrixDB ") + len("(MatrixDB ")
 	versionEnd := strings.Index(dbversion.VersionString, ")")
 	if versionStart >= 0 && versionEnd > versionStart {
 		dbversion.VersionString = dbversion.VersionString[versionStart:versionEnd]


### PR DESCRIPTION
It is true that `MatrixDB` has been officially named "YMatrix". However, for some historical reasons, while calling `pg_catalog.version()`, texts containing "MatrixDB" are still displaying for the client.
As a result, in the function we are to detect the version of `YMatrix` in order to decide which GUC names to use, we are still obliged to conform to the convention of legacy name of `MatrixDB`.