### PR TITLE
change generator and http writer debugging log to verbose

### DIFF
--- a/internal/engine/generator/telematics/telematics.go
+++ b/internal/engine/generator/telematics/telematics.go
@@ -107,12 +107,12 @@ func (g *Generator) Close() error {
 	g.cancelFunc()
 	g.wg.Wait()
 
-	log.Info("[Generator.TELEMATICS] Gen time: %s", time.Duration(accGenTime))
-	log.Info("[Generator.TELEMATICS] Write time: %s", time.Duration(accWriteTime))
-	log.Info("[Generator.TELEMATICS] Misc time1: %s", time.Duration(accMiscTime1))
-	log.Info("[Generator.TELEMATICS] Write Cnt: %d", accWriteCnt)
-	log.Info("[Generator.TELEMATICS] Acc Size: %d", accWriteSize)
-	log.Info("[Generator.TELEMATICS] Max Size: %d", maxWriteSize)
+	log.Verbose("[Generator.TELEMATICS] Gen time: %s", time.Duration(accGenTime))
+	log.Verbose("[Generator.TELEMATICS] Write time: %s", time.Duration(accWriteTime))
+	log.Verbose("[Generator.TELEMATICS] Misc time1: %s", time.Duration(accMiscTime1))
+	log.Verbose("[Generator.TELEMATICS] Write Cnt: %d", accWriteCnt)
+	log.Verbose("[Generator.TELEMATICS] Acc Size: %d", accWriteSize)
+	log.Verbose("[Generator.TELEMATICS] Max Size: %d", maxWriteSize)
 
 	return nil
 }

--- a/internal/engine/writer/http/http.go
+++ b/internal/engine/writer/http/http.go
@@ -337,12 +337,12 @@ func (w *Writer) Stop() error {
 	w.cancelFunc()
 	w.globalWG.Wait()
 
-	log.Info("Parallel: %d", w.hCfg.Parallel)
-	log.Info("Acc Post: %s", time.Duration(gAccPost))
-	log.Info("Num Post: %d", gNPost)
-	log.Info("Slowest Post: %s", time.Duration(gMaxPostTime))
-	log.Info("Acc Post Size: %d", gAccSize)
-	log.Info("Max Post Size: %d", gMaxSize)
+	log.Verbose("Parallel: %d", w.hCfg.Parallel)
+	log.Verbose("Acc Post: %s", time.Duration(gAccPost))
+	log.Verbose("Num Post: %d", gNPost)
+	log.Verbose("Slowest Post: %s", time.Duration(gMaxPostTime))
+	log.Verbose("Acc Post Size: %d", gAccSize)
+	log.Verbose("Max Post Size: %d", gMaxSize)
 
 	return nil
 }


### PR DESCRIPTION
Previously, in order to optimize the generator and http writer, it is added some logs to record time consumed for some critical intervals. However, it might make no sense to expose them to users whilst bringing some confusions.

In this PR, we are about to make them to the "Verbose" level, which will only be visible after configuring "log-level" as "verbose".

