### PR TITLE
exclude dump from query only mode

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -334,7 +334,9 @@ func (e *Engine) Run() error {
 	}
 
 	// no writing data
-	if e.Config.GeneratorCfg.Plugin == "nil" || e.Config.WriterCfg.Plugin == "nil" {
+	noWirterOrGenerator := e.Config.GeneratorCfg.Plugin == "nil" || e.Config.WriterCfg.Plugin == "nil"
+	qeuryOnlyMode := noWirterOrGenerator && !e.Config.GlobalCfg.Dump
+	if qeuryOnlyMode {
 		e.execDDLFunc = func() error { return nil }
 	}
 
@@ -358,7 +360,7 @@ func (e *Engine) Run() error {
 		}
 	}
 
-	if e.Config.GeneratorCfg.Plugin == "nil" || e.Config.WriterCfg.Plugin == "nil" {
+	if qeuryOnlyMode {
 		// When no writing data, get vin values from dest table
 		e.Metadata.Table.VinValues, err = e.getVinValuesFromTable()
 		if err != nil {


### PR DESCRIPTION
Previously, a "query-only mode"  is designed for `mxbench`. This happened when the "writer" or "generator" is "nil", implying that the user only wants `mxbench` to run queries. Thus, the step for creating table and loading data are skipped.

This is not supposed to be applied in the "dump" mode, in which the user would probably set "writer" to "nil" but anticipate generating data. So in this PR, we exclude "dump" from "query-only mode".