### PR TITLE
Support mxgate already started situation

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -625,7 +625,7 @@ func (e *Engine) execDDLFromFile() error {
 	_, err = conn.Exec(ddlFromFile)
 	if strings.Contains(err.Error(), "already exists") {
 		log.Warn(err.Error())
-		return nil
+		return confirmMsg()
 	}
 	return err
 }
@@ -749,4 +749,15 @@ func (e *Engine) backupGUCs() error {
 
 func (e *Engine) IsNil() bool {
 	return e == nil
+}
+
+func confirmMsg() error {
+	// ask for confirmation
+	fmt.Printf(NoticeColor, "Continue running mxbench with the existing table: Yy|Nn (default=N): ")
+	var confirmStr string
+	fmt.Scanln(&confirmStr)
+	if strings.ToLower(strings.TrimSpace(confirmStr)) != "y" {
+		return mxerror.CommonErrorf("User abort running mxbench with existing table, exitting...")
+	}
+	return nil
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -623,6 +623,10 @@ func (e *Engine) execDDLFromFile() error {
 	defer conn.Close()
 
 	_, err = conn.Exec(ddlFromFile)
+	if strings.Contains(err.Error(), "already exists") {
+		log.Warn(err.Error())
+		return nil
+	}
 	return err
 }
 

--- a/internal/engine/writer/http/http.go
+++ b/internal/engine/writer/http/http.go
@@ -406,6 +406,7 @@ func (w *Writer) GetDefaultFlags() (*pflag.FlagSet, interface{}) {
 	p.IntVar(&hCfg.StreamPrepared, "writer-stream-prepared", -1, "stream-prepared for mxgate")
 	p.IntVar(&hCfg.Interval, "writer-interval", -1, "interval for mxgate")
 	p.StringVar(&hCfg.mxgatePath, "writer-mxgate-path", "", "path of mxgate")
+	p.StringVar(&hCfg.MxgateURL, "writer-mxgate-url", "", "http url of mxgate")
 
 	p.StringVar(&hCfg.ProgressFormat, "writer-progress-format", "list", "progress format. support \"list\", \"json\"")
 	p.BoolVar(&hCfg.ProgressIncludeTableSize, "writer-progress-include-table-size", false, "whether progress include table size")

--- a/internal/engine/writer/http/http.go
+++ b/internal/engine/writer/http/http.go
@@ -22,13 +22,13 @@ import (
 )
 
 const (
-	_HEADER_CONTENT_ENCODING = "Content-Encoding"
-	_HEADER_GZIP             = "gzip"
-	_BATCH_SIZE              = 4 * 1024 * 1024
-	_BATCH_RED               = _BATCH_SIZE / 8 * 7
-	_METHOD_POST             = "POST"
-	_TEXT_PLAIN              = "text/plain"
-	_HTTP_PORT               = 8086
+	//_HEADER_CONTENT_ENCODING = "Content-Encoding"
+	//_HEADER_GZIP = "gzip"
+	_BATCH_SIZE  = 4 * 1024 * 1024
+	_BATCH_RED   = _BATCH_SIZE / 8 * 7
+	_METHOD_POST = "POST"
+	_TEXT_PLAIN  = "text/plain"
+	_HTTP_PORT   = 8086
 )
 
 var (


### PR DESCRIPTION
- Add a confirmed check for the existing table.
- Add a configuration param 'writer-mxgate-url', with this param configured, user can execute mxbench against mxgate already started situation.
   Leave it empty, if you prefer mxbench start mxgate internal.
   Set mxgate URL, such as 'http://localhost:8086', if you prefer the already stated mxgate.