### PR TITLE
Fix: missing database error

### DIFF
--- a/internal/util/gpstop.go
+++ b/internal/util/gpstop.go
@@ -3,7 +3,7 @@ package util
 import "fmt"
 
 func RestartDB() error {
-	outStr, err := runCmdAndDealingWithError(PSQL_BIN, "-c", "show mx_ha_provider")
+	outStr, _, err := ShowGUC("mx_ha_provider")
 	if err != nil || outStr == "" {
 		return fmt.Errorf("fail to show mx_ha_provider %v", err)
 	}


### PR DESCRIPTION
When specifying the database as "testdb" in the config, running mxbench still requires the existence of a database with the same name as the username.